### PR TITLE
Removes disc styling from table of content

### DIFF
--- a/skins/bento/css_local/style.css
+++ b/skins/bento/css_local/style.css
@@ -211,6 +211,10 @@ h1 .editsection, h2 .editsection, h3 .editsection {
     display: inline;
 }
 
+#toc ul {
+    list-style: none;
+}
+
 /* trying to move the flaggedrev box out of the way */
 .flaggedrevs_short {
     border: 1px solid #DDDDDD;


### PR DESCRIPTION
Removes the [discs that are placed on top of borders on table of contents](http://imgur.com/o25JZsp). Since the lists are pseudo ordered lists, there isn't really any need for bullet styling.