### PR TITLE
Fix footer (Novell -> SUSE LLC)

### DIFF
--- a/skins/bento/includes/footer.html
+++ b/skins/bento/includes/footer.html
@@ -2,7 +2,7 @@
 <div id="footer" class="container_12">
     <div id="footer-legal" class="border-top grid_12">
         <p>
-            &copy; 2011 Novell, Inc. and others.  All content  is made available under the terms
+            &copy; 2001-2017 SUSE LLC and others.  All content  is made available under the terms
             of the GNU Free Documentation License version 1.2 ("GFDL") unless expressly
             otherwise indicated. | <a href="/Terms_of_site">Terms of site</a>
         </p>


### PR DESCRIPTION
Hi @cboltz, as discussed at OSC, here is the fix for the footer.

SUSE LLC (no colon as in "Novell, Inc,") is the successor of Novell and the years (2001-2017) are taken from [SUSE's 'legal' page](https://www.suse.com/company/legal/#o), so it should be save to use.