### PR TITLE
More compact header

### DIFF
--- a/skins/Chameleon/SkinChameleon.php
+++ b/skins/Chameleon/SkinChameleon.php
@@ -167,7 +167,7 @@ class ChameleonTemplate extends BaseTemplate
             <!-- Page Header -->
             <header id="mw-head" class="my-3">
                 
-                <div class="d-flex justify-content-between justify-content-md-end my-3">
+                <div id="search-and-user" class="d-flex justify-content-between justify-content-md-end">
                     <!-- Search Form -->
                     <form action="<?php $this->text( 'wgScript' ) ?>" id="searchform" class="form-inline">
                         <div class="input-group">
@@ -251,7 +251,7 @@ class ChameleonTemplate extends BaseTemplate
                     
                 </div><!-- /. -->
 
-                <div class="my-3">
+                <div id="namespaces-variants" class="mb-2">
                     <!-- Tabs for talk page and language variants -->
                     <ul id="p-namespaces" class="nav nav-tabs"<?php $this->html( 'userlangattributes' ) ?>>
                         <?php foreach ($this->data['namespace_urls'] as $link) : ?>
@@ -281,7 +281,7 @@ class ChameleonTemplate extends BaseTemplate
                 </div>
 
                 <!-- Page Actions -->
-                <div class="btn-toolbar justify-content-end hidden-sm-down" role="toolbar" aria-label="Toolbar with button groups">
+                <div id="page-actions" class="btn-toolbar justify-content-end hidden-sm-down" role="toolbar" aria-label="Toolbar with button groups">
                     <div class="btn-group" role="group">
                         <?php foreach ($this->data['view_urls'] as $link) : ?>
                             <a class="btn btn-secondary" href="<?php echo htmlspecialchars( $link['href'] ) ?>" <?php echo $link['key'] ?>><?php
@@ -312,7 +312,7 @@ class ChameleonTemplate extends BaseTemplate
                 <!-- /sitenotice -->
                 <?php endif; ?>
                 <!-- firstHeading -->
-                <h1 id="firstHeading" class="firstHeading display-3 mb-5">
+                <h1 id="firstHeading" class="firstHeading display-3 mt-0 mb-3">
                     <span dir="auto"><?php $this->html( 'title' ) ?></span>
                 </h1>
                 <!-- /firstHeading -->

--- a/skins/Chameleon/SkinChameleon.php
+++ b/skins/Chameleon/SkinChameleon.php
@@ -282,20 +282,21 @@ class ChameleonTemplate extends BaseTemplate
 
                 <!-- Page Actions -->
                 <div class="btn-toolbar justify-content-end hidden-sm-down" role="toolbar" aria-label="Toolbar with button groups">
-                    <div class="btn-group" role="group" aria-label="First group">
+                    <div class="btn-group" role="group">
                         <?php foreach ($this->data['view_urls'] as $link) : ?>
-                            <a class="btn btn-secondary" <?php echo $link['attributes'] ?> href="<?php echo htmlspecialchars( $link['href'] ) ?>" <?php echo $link['key'] ?>><?php
+                            <a class="btn btn-secondary" href="<?php echo htmlspecialchars( $link['href'] ) ?>" <?php echo $link['key'] ?>><?php
                                 // $link['text'] can be undefined - bug 27764
                             if (array_key_exists( 'text', $link )) {
                                 echo array_key_exists( 'img', $link ) ?  '<img src="' . $link['img'] . '" alt="' . $link['text'] . '" />' : htmlspecialchars( $link['text'] );
                             }
                                 ?></a>
                         <?php endforeach; ?>
-                    </div>
-                    <div class="btn-group ml-2" role="group" aria-label="Second group">
-                        <?php foreach ($this->data['action_urls'] as $link) : ?>
-                            <a class="btn btn-secondary" <?php echo $link['attributes'] ?> href="<?php echo htmlspecialchars( $link['href'] ) ?>" <?php echo $link['key'] ?>><?php echo htmlspecialchars( $link['text'] ) ?></a>
-                        <?php endforeach; ?>
+                        <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></button>
+                        <div class="dropdown-menu dropdown-menu-right" aria-labelledby="btnGroupDrop1">
+                            <?php foreach ($this->data['action_urls'] as $link) : ?>
+                                <a class="dropdown-item" href="<?php echo htmlspecialchars( $link['href'] ) ?>" <?php echo $link['key'] ?>><?php echo htmlspecialchars( $link['text'] ) ?></a>
+                            <?php endforeach; ?>
+                        </div>
                     </div>
                 </div>
             </header>

--- a/skins/Chameleon/SkinChameleon.php
+++ b/skins/Chameleon/SkinChameleon.php
@@ -21,7 +21,6 @@ class SkinChameleon extends SkinTemplate
         parent::initPage( $out );
         $out->addMeta( 'viewport', 'width=device-width, initial-scale=1' );
         $out->addModules( 'skins.chameleon' );
-        $out->addModuleStyles( 'skins.chameleon' );
     }
 
     function setupSkinUserCss(OutputPage $out)

--- a/skins/Chameleon/wiki.css
+++ b/skins/Chameleon/wiki.css
@@ -33,6 +33,16 @@
     max-width: 1200px;
 }
 
+#search-and-user {
+    margin-bottom: -32px;
+}
+
+@media (max-width: 768px) {
+    #search-and-user {
+        margin-bottom: 20px;
+    }
+}
+
 /* User menu */
 
 #user-menu-button .avatar {


### PR DESCRIPTION
Combine page tabs, search and user menu into one row. Reduce margins between header and page title.

![2017-08-01 01 32 13](https://user-images.githubusercontent.com/5836790/28801294-914a571e-7659-11e7-80a1-bfcf6bfc9126.png)
