### PR TITLE
Style updates for new skin

### DIFF
--- a/skins/Chameleon/SkinChameleon.php
+++ b/skins/Chameleon/SkinChameleon.php
@@ -283,7 +283,7 @@ class ChameleonTemplate extends BaseTemplate
                 </div>
 
                 <!-- Page Actions -->
-                <div id="page-actions" class="btn-toolbar justify-content-end hidden-sm-down" role="toolbar" aria-label="Toolbar with button groups">
+                <div id="page-actions" class="btn-toolbar float-right hidden-sm-down" role="toolbar" aria-label="Toolbar with button groups">
                     <div class="btn-group btn-group-sm" role="group">
                         <?php foreach ($this->data['view_urls'] as $link) : ?>
                             <a class="btn btn-secondary" href="<?php echo htmlspecialchars( $link['href'] ) ?>" <?php echo $link['key'] ?>><?php

--- a/skins/Chameleon/SkinChameleon.php
+++ b/skins/Chameleon/SkinChameleon.php
@@ -185,7 +185,7 @@ class ChameleonTemplate extends BaseTemplate
                             </button>
                             <div class="dropdown-menu dropdown-menu-right">
                                 <a class="dropdown-item" href="<?php echo $this->data['signup_url'] ?>"><?php echo $this->msg('createaccount') ?></a>
-                                <a class="dropdown-item" href="#" class="nav-link" data-toggle="modal" data-target="#login-modal"><?php echo $this->msg('login') ?></a>
+                                <a class="dropdown-item" href="#" data-toggle="modal" data-target="#login-modal"><?php echo $this->msg('login') ?></a>
                             </div>
                         </div><!-- /.dropdown -->
 
@@ -202,7 +202,7 @@ class ChameleonTemplate extends BaseTemplate
                                         </div>
                                         <div class="modal-body">
                                         
-                                            <input name="target" value="http://<?php echo $_SERVER['SERVER_NAME'] . $this->data['personal_urls']['login']['href'] ?>" type="hidden"/>
+                                            <input name="target" value="http://<?php echo $_SERVER['SERVER_NAME'] . htmlentities($this->data['personal_urls']['login']['href']) ?>" type="hidden"/>
                                             <input name="context" value="default" type="hidden"/>
                                             <input name="proxypath" value="reverse" type="hidden"/>
                                             <input name="message" value="Please log In" type="hidden"/>

--- a/skins/Chameleon/SkinChameleon.php
+++ b/skins/Chameleon/SkinChameleon.php
@@ -20,7 +20,8 @@ class SkinChameleon extends SkinTemplate
     {
         parent::initPage( $out );
         $out->addMeta( 'viewport', 'width=device-width, initial-scale=1' );
-        $out->addModules( 'skins.chameleon' );
+        $out->addModuleStyles( 'skins.chameleon' );
+        $out->addModules( 'skins.chameleon.js' );
     }
 
     function setupSkinUserCss(OutputPage $out)

--- a/skins/Chameleon/SkinChameleon.php
+++ b/skins/Chameleon/SkinChameleon.php
@@ -180,7 +180,7 @@ class ChameleonTemplate extends BaseTemplate
 
                         <!-- Login Menu -->
                         <div class="dropdown ml-2">
-                            <button class="btn btn-secondary dropdown-toggle" type="button" id="user-menu-button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                            <button class="btn btn-primary" type="button" id="user-menu-button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                 <?php echo $this->msg('login') ?>
                             </button>
                             <div class="dropdown-menu dropdown-menu-right">
@@ -228,9 +228,9 @@ class ChameleonTemplate extends BaseTemplate
 
                     <?php else : ?>
                         <div class="dropdown ml-2">
-                            <button class="btn btn-secondary dropdown-toggle" type="button" id="user-menu-button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                            <button class="btn btn-primary" type="button" id="user-menu-button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                 <img class="avatar" src="<?php echo $this->data['gravatar'] ?>" width="80" height="80" />
-                                <span class="hidden-xs-down"><?php echo $this->data['username'] ?></span>
+                                <span class="name hidden-xs-down"><?php echo $this->data['username'] ?></span>
                             </button>
                             <div class="dropdown-menu dropdown-menu-right">
                                 <?php
@@ -282,7 +282,7 @@ class ChameleonTemplate extends BaseTemplate
 
                 <!-- Page Actions -->
                 <div id="page-actions" class="btn-toolbar justify-content-end hidden-sm-down" role="toolbar" aria-label="Toolbar with button groups">
-                    <div class="btn-group" role="group">
+                    <div class="btn-group btn-group-sm" role="group">
                         <?php foreach ($this->data['view_urls'] as $link) : ?>
                             <a class="btn btn-secondary" href="<?php echo htmlspecialchars( $link['href'] ) ?>" <?php echo $link['key'] ?>><?php
                                 // $link['text'] can be undefined - bug 27764
@@ -291,12 +291,14 @@ class ChameleonTemplate extends BaseTemplate
                             }
                                 ?></a>
                         <?php endforeach; ?>
-                        <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></button>
-                        <div class="dropdown-menu dropdown-menu-right" aria-labelledby="btnGroupDrop1">
-                            <?php foreach ($this->data['action_urls'] as $link) : ?>
-                                <a class="dropdown-item" href="<?php echo htmlspecialchars( $link['href'] ) ?>" <?php echo $link['key'] ?>><?php echo htmlspecialchars( $link['text'] ) ?></a>
-                            <?php endforeach; ?>
-                        </div>
+                        <?php if ($this->data['action_urls']) : ?>
+                            <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></button>
+                            <div class="dropdown-menu dropdown-menu-right" aria-labelledby="btnGroupDrop1">
+                                <?php foreach ($this->data['action_urls'] as $link) : ?>
+                                    <a class="dropdown-item" href="<?php echo htmlspecialchars( $link['href'] ) ?>" <?php echo $link['key'] ?>><?php echo htmlspecialchars( $link['text'] ) ?></a>
+                                <?php endforeach; ?>
+                            </div>
+                        <?php endif ?>
                     </div>
                 </div>
             </header>
@@ -312,7 +314,7 @@ class ChameleonTemplate extends BaseTemplate
                 <!-- /sitenotice -->
                 <?php endif; ?>
                 <!-- firstHeading -->
-                <h1 id="firstHeading" class="firstHeading display-3 mt-0 mb-3">
+                <h1 id="firstHeading" class="firstHeading display-4 mt-0 mb-3">
                     <span dir="auto"><?php $this->html( 'title' ) ?></span>
                 </h1>
                 <!-- /firstHeading -->

--- a/skins/Chameleon/SkinChameleon.php
+++ b/skins/Chameleon/SkinChameleon.php
@@ -102,7 +102,7 @@ class ChameleonTemplate extends BaseTemplate
                 array_reverse( $this->data['personal_urls'] );
         }
 
-        $this->data['login_url'] = "https://login.microfocus.com/nidp/idff/sso?sid=0";
+        $this->data['login_url'] = '/ICSLogin/auth-up';
         $this->data['signup_url'] = "https://secure-www.novell.com/selfreg/jsp/createOpenSuseAccount.jsp?login=Sign+up";
 
         if ($this->data['username']) {
@@ -202,21 +202,22 @@ class ChameleonTemplate extends BaseTemplate
                                             </button>
                                         </div>
                                         <div class="modal-body">
-                                        
-                                            <input name="target" value="http://<?php echo $_SERVER['SERVER_NAME'] . htmlentities($this->data['personal_urls']['login']['href']) ?>" type="hidden"/>
+
+                                            <input name="url" value="https://<?php echo $_SERVER['SERVER_NAME'] . htmlentities($_SERVER['REQUEST_URI']) ?>" type="hidden">
+                                            <input name="return_to_path" value="<?php echo htmlentities($_SERVER['REQUEST_URI']) ?>" type="hidden">
                                             <input name="context" value="default" type="hidden"/>
                                             <input name="proxypath" value="reverse" type="hidden"/>
                                             <input name="message" value="Please log In" type="hidden"/>
-                                            
+
                                             <div class="form-group">
                                                 <label for="login-username"><?php echo $this->msg('userlogin-yourname') ?></label>
-                                                <input type="text" class="form-control" name="Ecom_User_ID" value="" id="login-username" />
+                                                <input type="text" class="form-control" name="username" value="" id="login-username" />
                                             </div>
                                             <div class="form-group">
                                                 <label for="login-password"><?php echo $this->msg('userlogin-yourpassword') ?></label>
-                                                <input type="password" class="form-control" name="Ecom_Password" value="" id="login-password" />
+                                                <input type="password" class="form-control" name="password" value="" id="login-password" />
                                             </div>
-                                            
+
                                         </div>
                                         <div class="modal-footer">
                                             <button type="button" class="btn btn-secondary" data-dismiss="modal"><?php echo $this->msg('cancel') ?></button>
@@ -555,3 +556,4 @@ var _paq = _paq || [];
     }
 }
 
+# vim:expandtab

--- a/skins/Chameleon/SkinChameleon.php
+++ b/skins/Chameleon/SkinChameleon.php
@@ -255,7 +255,7 @@ class ChameleonTemplate extends BaseTemplate
                     <!-- Tabs for talk page and language variants -->
                     <ul id="p-namespaces" class="nav nav-tabs"<?php $this->html( 'userlangattributes' ) ?>>
                         <?php foreach ($this->data['namespace_urls'] as $link) : ?>
-                            <li <?php echo str_replace('class="', 'class="nav-item ', $link['attributes']) ?>>
+                            <li class="nav-item">
                                 <a class="nav-link <?php echo strpos($link['attributes'], 'selected') ? 'active' : '' ?>" href="<?php echo htmlspecialchars( $link['href'] ) ?>" <?php echo $link['key'] ?>>
                                     <?php echo htmlspecialchars( $link['text'] ) ?>
                                 </a>

--- a/skins/Chameleon/skin.json
+++ b/skins/Chameleon/skin.json
@@ -29,7 +29,10 @@
 				"wiki.css": {
 					"media": "screen"
 				}
-			},
+			}
+		},
+		"skins.chameleon.js": {
+			"position": "bottom",
 			"scripts": [
 				"res/js/app-no-jquery.js",
 				"wiki.js"

--- a/skins/Chameleon/wiki.css
+++ b/skins/Chameleon/wiki.css
@@ -94,13 +94,17 @@
 
 #toc ul {
     list-style: none;
-    margin-top: 1em;
-    margin-bottom: 0;
+    margin: 0;
+    padding: 0;
+}
+
+#toc ul ul {
+    padding-left: 1em;
 }
 
 .tocnumber {
     display: inline-block;
-    min-width: 1.5em;
+    min-width: 1em;
 }
 
 /* Edit section button */

--- a/skins/Chameleon/wiki.css
+++ b/skins/Chameleon/wiki.css
@@ -45,12 +45,21 @@
 
 /* User menu */
 
+#user-menu-button {
+    position: relative;
+    overflow: hidden;    
+}
+
 #user-menu-button .avatar {
-    width: 1.8em;
-    height: 1.8em;
-    border-radius: 1em;
-    margin: -0.4em 0 -0.4em -0.5em;
-    vertical-align: middle;
+    position: absolute;
+    width: 36px;
+    height: 36px;
+    left: 0;
+    top: 0;
+}
+
+#user-menu-button .name {
+    margin-left: 30px;
 }
 
 /* Table of content */

--- a/skins/Chameleon/wiki.css
+++ b/skins/Chameleon/wiki.css
@@ -109,9 +109,12 @@
 
 /* Edit section button */
 
+.mw-editsection {
+    float: right;
+    margin-left: 0.5rem;
+}
+
 .mw-editsection a {
-    font-size: 1rem;
-    margin-left: 1rem;
     font-family: "Open Sans", sans-serif;
     font-weight: normal;
     vertical-align: middle;

--- a/skins/Chameleon/wiki.css
+++ b/skins/Chameleon/wiki.css
@@ -119,11 +119,16 @@
 
 /* Categories */
 
+.catlinks {
+    clear: both;
+}
+
 .mw-normal-catlinks {
     background: #ffffff;
     padding: 0.5em 1em;
     margin: 2em 0;
     border-left: 3px solid #73BA25;
+    clear: both;
 }
 
 .mw-normal-catlinks li {

--- a/skins/Chameleon/wiki.css
+++ b/skins/Chameleon/wiki.css
@@ -153,8 +153,10 @@ h3,
 h4,
 h5,
 h6 {
-    margin-top: 1rem;
-    margin-bottom: 1rem;
+    margin-top: 1rem !important;
+    margin-bottom: 1rem !important;
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
 }
 
 ul {

--- a/skins/Chameleon/wiki.js
+++ b/skins/Chameleon/wiki.js
@@ -6,3 +6,6 @@ jQuery('.mw-editsection a').addClass('btn btn-secondary btn-sm');
 
 // table
 jQuery('#bodyContent table').addClass('table').addClass('table-responsive');
+
+// Remove some MediaWiki classes that override skin styles
+jQuery('.mw-content-ltr').removeClass('mw-content-ltr');

--- a/skins/Chameleon/wiki.js
+++ b/skins/Chameleon/wiki.js
@@ -1,5 +1,13 @@
+// .card unnecessary <p> tag by MediaWiki
+jQuery('.card > p, .card-block > p:not(.card-title):not(.card-text)').each(function () {
+    jQuery(this).after(jQuery(this).html());
+    jQuery(this).remove();
+});
+
 // .card-image
 jQuery('.card img').addClass('card-img-top img-fluid');
+// .card-link
+jQuery('.card .card-block')
 
 // .mw-editsection
 jQuery('.mw-editsection a').addClass('btn btn-secondary btn-sm');

--- a/skins/Chameleon/wiki.js
+++ b/skins/Chameleon/wiki.js
@@ -10,7 +10,7 @@ jQuery('.card img').addClass('card-img-top img-fluid');
 jQuery('.card .card-block')
 
 // .mw-editsection
-jQuery('.mw-editsection a').addClass('btn btn-secondary btn-sm');
+jQuery('.mw-editsection a').addClass('btn btn-info btn-sm float-right');
 
 // table
 jQuery('#bodyContent table').addClass('table').addClass('table-responsive');


### PR DESCRIPTION
After trying on en-test.opensuse.org, I found and fixed some layout bugs. Things fixed and improved are:

1. Load styles and scripts separately. Styles should be load on the top, so HTML won't render before styles were loaded. Scripts should be loaded at the bottom to avoid waiting.
2. Hide dropdown button on page actions if here is no action at all. Action buttons are smaller than before.
3. Fix several class name mistakes in HTML. Duplicate or missing class="" property will cause style problem.
4. Avatar is bigger than before. Login button and user menu button use an outstanding color.
5. Page title is smaller.

![spectacle bh7468](https://user-images.githubusercontent.com/5836790/29248969-18ec46d6-802e-11e7-90e1-733b4bdff4a9.png)
