### PR TITLE
Change site name to mention wiki. Fix #21

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -61,7 +61,7 @@ if ( $wgCommandLineMode ) {
 # Basics
 #-------------------------------------------------------------------------------
 
-$wgSitename = "openSUSE";
+$wgSitename = "openSUSE Wiki";
 $wgMetaNamespace = "OpenSUSE";
 
 # Allow to display title different than actual page title


### PR DESCRIPTION
Simply change `$wgSiteName` to **openSUSE Wiki**, so users know this is wiki page. It is useful when users have many openSUSE webpages open in browser. They can identify page by title on browser tab.