### PR TITLE
Disable SVG uploading since don't have ImagicMagic

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -190,7 +190,6 @@ $wgFileExtensions = [
 	'png',
 	'ppt',
 	'pptx',
-	'svg',
 	'sxc',
 	'sxw',
 	'xls',


### PR DESCRIPTION
SVG uploading will fail if here is no ImagicMagic generating thumbnails.

I propose to remove SVG support. It is not very secure and rarely used. Users can always generate PNG and upload them.