### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/skins/bento/bento.php
+++ b/skins/bento/bento.php
@@ -97,7 +97,7 @@ class BentoTemplate extends QuickTemplate {
             </div>
 
 
-        <?php if( $this->data['username'] == NULL ) { ?>
+        <?php if( $this->data['username'] == null ) { ?>
             <div id="login-wrapper" class="grid_4 omega">
                 <a href="https://www.suse.com/selfreg/jsp/createOpenSuseAccount.jsp?login=Sign+up">Sign up</a> | <a id="login-trigger" href="/ICSLogin/auth-up/?url=https://<?php echo $_SERVER['SERVER_NAME'] . htmlentities($_SERVER['REQUEST_URI']) ?>">Login</a>
                 <!-- <a href="<?php //echo $this->data['personal_urls'][login][href] ?>">Sign up</a> | <a id="login-trigger" href="#login">Login</a> -->


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!