### PR TITLE
Fix toc sticky

### DIFF
--- a/skins/Chameleon/SkinChameleon.php
+++ b/skins/Chameleon/SkinChameleon.php
@@ -268,9 +268,7 @@ class ChameleonTemplate extends BaseTemplate
 			</footer>
 
 		</div><!-- /.col -->
-		<div class="d-none d-xl-block col-xl-2 noprint">
-			<aside id="toc-sidebar"></aside>
-		</div><!-- /.col -->
+		<div id="toc-sidebar" class="d-none d-xl-block col-xl-2 noprint"></div><!-- /.col -->
 	</div><!-- /.row -->
 </div><!-- /.container-fluid -->
 


### PR DESCRIPTION
The reason why sticky is not working: its parent element has the same height as it. Only when the parent is higher than child, the child can be sticky positioned.