### PR TITLE
Update footer links

### DIFF
--- a/skins/Chameleon/parts/global-footer.php
+++ b/skins/Chameleon/parts/global-footer.php
@@ -65,9 +65,6 @@
 						<a href="https://www.facebook.com/en.openSUSE">Facebook</a>
 					</li>
 					<li>
-						<a href="https://plus.google.com/+openSUSE">Google+</a>
-					</li>
-					<li>
 						<a href="https://twitter.com/opensuse">Twitter</a>
 					</li>
 					<li>

--- a/skins/Chameleon/parts/global-footer.php
+++ b/skins/Chameleon/parts/global-footer.php
@@ -48,6 +48,9 @@
 						<a class="l10n" data-msg-id="connect" href="https://connect.opensuse.org/">Connect</a>
 					</li>
 					<li>
+						<a href="https://discord.gg/opensuse">Discord</a>
+					</li>
+					<li>
 						<a class="l10n" data-msg-id="facebook-group" href="https://www.facebook.com/groups/opensuseproject/">Facebook group</a>
 					</li>
 					<li>


### PR DESCRIPTION
Google+ has been discontinued and therefore removed.

Discord is another important meeting place for the community and should therefore be listed as a contact point.