### PR TITLE
LeapVersion extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /docs
 /extensions/*
 !/extensions/*.php
+!/extensions/LeapVersion
 /images
 /includes
 /languages

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -379,6 +379,10 @@ $wgDefaultSkin = "Chameleon";
 # Extensions
 #-------------------------------------------------------------------------------
 
+##### Leap version variable provider
+
+wfLoadExtension( 'LeapVersion' );
+
 ##### Login proxy / Auth_remoteuser
 
 wfLoadExtension( 'Auth_remoteuser' );

--- a/extensions/LeapVersion/LeapVersion.php
+++ b/extensions/LeapVersion/LeapVersion.php
@@ -1,0 +1,8 @@
+<?php
+
+if ( function_exists( 'wfLoadExtension' ) ) {
+	wfLoadExtension( 'LeapVersion' );
+	return true;
+} else {
+	die( 'This version of the LeapVersion extension requires MediaWiki 1.25+' );
+}

--- a/extensions/LeapVersion/LeapVersionHooks.php
+++ b/extensions/LeapVersion/LeapVersionHooks.php
@@ -1,0 +1,16 @@
+<?php
+
+class LeapVersionHooks {
+	public static function onParserBeforeInternalParse( &$parser, &$text, &$strip_state )
+	{
+		$versions = [
+			'LEAP_VERSION' => '15.1',
+			'LEAP_VERSION_OLD' => '15.0',
+			'LEAP_VERSION_OLDER' => '42.3',
+		];
+
+		foreach ($versions as $key => $value) {
+			$text = str_replace('{{'.$key.'}}', $value, $text);
+		}
+	}
+}

--- a/extensions/LeapVersion/extension.json
+++ b/extensions/LeapVersion/extension.json
@@ -1,0 +1,16 @@
+{
+	"name": "LeapVersion",
+	"version": "0.0.1",
+	"author": ["Guo Yunhe"],
+	"url": "https://github.com/openSUSE/wiki",
+	"description": "Provide variables of Leap version numbers",
+	"license-name": "GPL-3.0",
+	"type": "other",
+	"Hooks": {
+		"ParserBeforeInternalParse": "LeapVersionHooks::onParserBeforeInternalParse"
+	},
+	"AutoloadClasses": {
+		"LeapVersionHooks": "LeapVersionHooks.php"
+	},
+	"manifest_version": 1
+}


### PR DESCRIPTION
This extension brings some variables that can be used in MediaWiki:

```html
<SyntaxHighlight>
# Leap {{LEAP_VERSION}}
sudo zypper addrepo --refresh --priority 90 https://ftp.gwdg.de/pub/linux/misc/packman/suse/openSUSE_Leap_{{LEAP_VERSION}}/packman.repo

# Leap {{LEAP_VERSION_OLD}}
sudo zypper addrepo --refresh --priority 90 https://ftp.gwdg.de/pub/linux/misc/packman/suse/openSUSE_Leap_{{LEAP_VERSION_OLD}}/packman.repo

# Leap {{LEAP_VERSION_OLDER}}
sudo zypper addrepo --refresh --priority 90 https://ftp.gwdg.de/pub/linux/misc/packman/suse/openSUSE_Leap_{{LEAP_VERSION_OLDER}}/packman.repo
</SyntaxHighlight>
```

Render to:

```bash
# Leap 15.1
sudo zypper addrepo --refresh --priority 90 https://ftp.gwdg.de/pub/linux/misc/packman/suse/openSUSE_Leap_15.1/packman.repo

# Leap 15.0
sudo zypper addrepo --refresh --priority 90 https://ftp.gwdg.de/pub/linux/misc/packman/suse/openSUSE_Leap_15.0/packman.repo

# Leap 42.3
sudo zypper addrepo --refresh --priority 90 https://ftp.gwdg.de/pub/linux/misc/packman/suse/openSUSE_Leap_42.3/packman.repo
```

Once the new Leap 15.2 released, we just change the three variables in the extension, and all pages of all wikis will be updated.

`<pre>` and `<SyntaxHighlight>` tag will escape all template or parser markups. So this extension used a more low-end hook to process the variables. So they can be used anywhere.