### PR TITLE
Balanced layout for big screen

### DIFF
--- a/skins/Chameleon/SkinChameleon.php
+++ b/skins/Chameleon/SkinChameleon.php
@@ -106,16 +106,18 @@ class ChameleonTemplate extends BaseTemplate
 <?php include(__DIR__ . '/parts/navbar.php'); ?>
 
 <!-- Main Wrap -->
-<div id="main-wrap" class="container-fluid">
-	<div class="row">
-		<div class="col-12 col-lg-9">
-			<?php include(__DIR__ . '/parts/header.php'); ?>
-			<?php include(__DIR__ . '/parts/content.php'); ?>
-		</div><!-- /.col -->
-		<div id="toc-sidebar" class="d-none d-lg-block col-lg-3 noprint">
-		</div><!-- /.col -->
-	</div><!-- /.row -->
-</div><!-- /.container-fluid -->
+<div id="main-wrap">
+	<div class="wiki-container container-fluid">
+		<div class="row">
+				<div id="main" class="col-12">
+				<?php include(__DIR__ . '/parts/header.php'); ?>
+				<?php include(__DIR__ . '/parts/content.php'); ?>
+			</div><!-- /.col -->
+				<div id="toc-sidebar" class="d-none noprint">
+			</div><!-- /.col -->
+		</div><!-- /.row -->
+	</div><!-- /.container-fluid -->
+</div><!-- /.main-wrap -->
 
 <?php include(__DIR__ . '/parts/footer.php'); ?>
 <?php include(__DIR__ . '/parts/login-modal.php'); ?>

--- a/skins/Chameleon/SkinChameleon.php
+++ b/skins/Chameleon/SkinChameleon.php
@@ -107,7 +107,7 @@ class ChameleonTemplate extends BaseTemplate
 
 <!-- Main Wrap -->
 <div id="main-wrap">
-	<div class="wiki-container container-fluid">
+	<div class="container">
 		<div class="row">
 				<div id="main" class="col-12">
 				<?php include(__DIR__ . '/parts/header.php'); ?>

--- a/skins/Chameleon/parts/footer.php
+++ b/skins/Chameleon/parts/footer.php
@@ -1,5 +1,5 @@
 <footer id="site-footer" class="site-footer noprint"<?php $this->html( 'userlangattributes' ) ?>>
-    <div class="container-fluid">
+	<div class="wiki-container container-fluid">
 		<div class="row">
 			<div class="col-12 col-lg-9">
 				<?php foreach ($this->getFooterLinks() as $category => $links) : ?>
@@ -17,5 +17,5 @@
 				<?php include __DIR__ . '/sponsors.php'; ?>
 			</div><!-- /.col-* -->
 		</div><!-- /.row -->
-    </div><!-- /.container -->
+	</div><!-- /.container -->
 </footer>

--- a/skins/Chameleon/parts/footer.php
+++ b/skins/Chameleon/parts/footer.php
@@ -1,5 +1,5 @@
 <footer id="site-footer" class="site-footer noprint"<?php $this->html( 'userlangattributes' ) ?>>
-	<div class="wiki-container container-fluid">
+	<div class="container">
 		<div class="row">
 			<div class="col-12 col-lg-9">
 				<?php foreach ($this->getFooterLinks() as $category => $links) : ?>


### PR DESCRIPTION
Limit the maximum width of container.

For pages without TOC, like Main Page, Portals, Search results, the max content width is about `1110px`.

![image](https://user-images.githubusercontent.com/5836790/62162297-9dd7c600-b320-11e9-901d-a2df0446b077.png)

For pages with TOC, like application, SDB, article pages, the max content width is about `825px`.

![image](https://user-images.githubusercontent.com/5836790/62162276-92849a80-b320-11e9-8381-b9375e0fb1d1.png)

Content area is centered. Both side have spaces on big screen. (It will take an hour for static.opensuse.org to fetch latest CSS)