### PR TITLE
Update chameleon

### DIFF
--- a/skins/Chameleon/SkinChameleon.php
+++ b/skins/Chameleon/SkinChameleon.php
@@ -21,7 +21,9 @@ class SkinChameleon extends SkinTemplate
         parent::initPage( $out );
         $out->addMeta( 'viewport', 'width=device-width, initial-scale=1' );
         $out->addStyle( 'https://static.opensuse.org/chameleon/dist/css/chameleon.css' );
+        $out->addStyle( 'https://static.opensuse.org/chameleon/dist/css/chameleon-wiki.css' );
         $out->addScriptFile( 'https://static.opensuse.org/chameleon/dist/js/chameleon-no-jquery.js' );
+        $out->addScriptFile( 'https://static.opensuse.org/chameleon/dist/js/chameleon-wiki.js' );
     }
 
     function setupSkinUserCss(OutputPage $out)

--- a/skins/Chameleon/parts/footer.php
+++ b/skins/Chameleon/parts/footer.php
@@ -1,19 +1,27 @@
-<footer id="site-footer" class="site-footer noprint"<?php $this->html( 'userlangattributes' ) ?>>
+<footer class="footer noprint"<?php $this->html( 'userlangattributes' ) ?>>
 	<div class="container">
 		<div class="row">
-			<div class="col-12 col-lg-9">
+			<div class="col-lg-9">
 				<?php foreach ($this->getFooterLinks() as $category => $links) : ?>
-					<p>
-						<?php foreach ($links as $link) : ?>
-							<?php $this->html( $link ) ?>
-						<?php endforeach; ?>
-					</p>
+					<?php if ($category === 'places'): ?>
+						<ul id="footer-<?= $category ?>" class="list-inline">
+							<?php foreach ($links as $link) : ?>
+								<li class="list-inline-item"><?php $this->html( $link ) ?></li>
+							<?php endforeach; ?>
+						</ul>
+					<?php else: ?>
+						<p id="footer-<?= $category ?>">
+							<?php foreach ($links as $link) : ?>
+								<?php $this->html( $link ) ?>
+							<?php endforeach; ?>
+						</p>
+					<?php endif; ?>
 				<?php endforeach; ?>
-				<p>
-					&copy; 2001&ndash;<?php echo date('Y') ?> SUSE LLC, &copy; 2005&ndash;<?php echo date('Y') ?> openSUSE Contributors &amp; others.
+				<p id="footer-copyright">
+					&copy; 2001&ndash;<?php echo date('Y') ?> SUSE LLC, &copy; 2005&ndash;<?php echo date('Y') ?> openSUSE contributors &amp; others.
 				</p>
 			</div><!-- /.col-* -->
-			<div class="col-12 col-lg-3">
+			<div class="col-lg-3">
 				<?php include __DIR__ . '/sponsors.php'; ?>
 			</div><!-- /.col-* -->
 		</div><!-- /.row -->

--- a/skins/Chameleon/parts/login-modal.php
+++ b/skins/Chameleon/parts/login-modal.php
@@ -27,6 +27,9 @@
 
 				</div>
 				<div class="modal-footer">
+					<a class="btn btn-link" href="<?php echo $this->data['signup_url'] ?>">
+						<?php echo $this->msg('createaccount') ?>
+					</a>
 					<button type="button" class="btn btn-secondary" data-dismiss="modal"><?php echo $this->msg('cancel') ?></button>
 					<button type="submit" class="btn btn-primary"><?php echo $this->msg('login') ?></button>
 				</div>

--- a/skins/Chameleon/parts/navbar.php
+++ b/skins/Chameleon/parts/navbar.php
@@ -1,6 +1,8 @@
 <nav class="navbar navbar-expand-md navbar-light bg-light noprint">
     <a class="navbar-brand" href="/">
-		<img src="https://static.opensuse.org/chameleon/dist/images/logo/logo-white.svg" class="mr-2" alt="Logo">
+		<svg class="icon icon-2x mr-2">
+			<use xlink:href="#opensuse">
+		</svg>
 		<span class="l10n" data-msg-id="wiki">Wiki</span>
     </a>
 

--- a/skins/Chameleon/parts/navbar.php
+++ b/skins/Chameleon/parts/navbar.php
@@ -21,23 +21,21 @@
 			<!-- User Menu -->
 			<?php if ($this->data['username'] == null) : ?>
 				<li class="nav-item">
-					<a class="nav-link" href="<?php echo $this->data['signup_url'] ?>">
-						<?php echo $this->msg('createaccount') ?>
-					</a>
-				</li>
-				<li class="nav-item">
-					<a id="login-modal-toggle" class="nav-link" href="#" data-toggle="modal" data-target="#login-modal">
-						<?php echo $this->msg('login') ?>
+					<a id="login-modal-toggle" class="nav-link" href="#" data-toggle="modal" data-target="#login-modal" title="<?= $this->msg('login') ?>">
+						<svg class="icon">
+							<use xlink:href="#login-box-line">
+						</svg>
+						<span class="d-md-none"><?= $this->msg('login') ?></span>
 					</a>
 				</li>
 			<?php else : ?>
 				<li class="nav-item dropdown">
-					<a class="nav-link dropdown-toggle" href="#" id="user-dropdown"
+					<a class="nav-link" href="#" id="user-dropdown"
 					   	role="button" data-toggle="dropdown" aria-haspopup="true"
 					   	aria-expanded="false">
-						<img class="avatar rounded" src="<?php echo $this->data['gravatar'] ?>"
+						<img class="avatar" src="<?php echo $this->data['gravatar'] ?>"
 						 	width="40" height="40" alt="Avatar" title="<?php echo $this->data['username'] ?>"/>
-						<span class="ml-1"><?php echo $this->data['username'] ?></span>
+						<span class="ml-1 d-md-none"><?php echo $this->data['username'] ?></span>
 					</a>
 					<div class="dropdown-menu dropdown-menu-right" aria-labelledby="user-dropdown">
 						<?php
@@ -57,4 +55,6 @@
 			<?php endif; ?>
 		</ul>
     </div>
+
+	<button class="navbar-toggler megamenu-toggler" type="button"><svg class="icon"><use xlink:href="#apps-line"></use></svg></button>
 </nav>

--- a/skins/Chameleon/parts/search-form.php
+++ b/skins/Chameleon/parts/search-form.php
@@ -1,3 +1,12 @@
 <form action="<?php $this->text( 'wgScript' ) ?>" id="searchform" class="form-inline">
-	<?php echo $this->makeSearchInput( array( 'id' => 'searchInput', 'class' => 'form-control', 'type' => 'search' ) ); ?>
+	<div class="input-group">
+		<?php echo $this->makeSearchInput( array( 'id' => 'searchInput', 'class' => 'form-control', 'type' => 'search' ) ); ?>
+		<div class="input-group-append">
+			<button class="btn btn-secondary" type="submit">
+				<svg class="icon">
+					<use xlink:href="#search-line">
+				</svg>
+			</button>
+		</div>
+	</div>
 </form>

--- a/skins/Chameleon/parts/search-form.php
+++ b/skins/Chameleon/parts/search-form.php
@@ -1,4 +1,4 @@
-<form action="<?php $this->text( 'wgScript' ) ?>" id="searchform" class="form-inline">
+<form action="<?php $this->text( 'wgScript' ) ?>" id="searchform" class="form-inline mr-md-2">
 	<div class="input-group">
 		<?php echo $this->makeSearchInput( array( 'id' => 'searchInput', 'class' => 'form-control', 'type' => 'search' ) ); ?>
 		<div class="input-group-append">


### PR DESCRIPTION
Wiki styles and scripts are now in separate files: chameleon-wiki.css and chameleon-wiki.js

Improved search bar and footer styles

![image](https://user-images.githubusercontent.com/5836790/75865548-62e4c600-5e0c-11ea-83ba-93105dfd2cf8.png)

You may noticed that here are two link icons after headings. That is because the wiki scripts are still bundled in to `chameleon-no-jquery.js`. After deployed, I will immediately disable it and there will be only one icon.