### PR TITLE
Allow appstream: protocol

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -246,6 +246,8 @@ $wgAllowExternalImages = true;
 
 # Add XMPP functionality
 $wgUrlProtocols[] = 'xmpp:';
+# Add AppStream functionality
+$wgUrlProtocols[] = 'appstream:';
 
 # Category watching
 # see https://www.mediawiki.org/wiki/Manual:CategoryMembershipChanges


### PR DESCRIPTION
By enabling `appstream:` protocol, users can click a link and open app center app (GNOME Software or KDE Discover) and install the application easily.